### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://shawnoster.visualstudio.com/5e1d907d-b0b4-4272-be99-f3ac5c2e7a67/d5f5307e-41cf-4213-b276-aeabbe419a5e/_apis/work/boardbadge/535d3815-5607-47d2-a109-a8d1e277201f)](https://shawnoster.visualstudio.com/5e1d907d-b0b4-4272-be99-f3ac5c2e7a67/_boards/board/t/d5f5307e-41cf-4213-b276-aeabbe419a5e/Microsoft.RequirementCategory)
 # nightowlcli
 
 ```


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://shawnoster.visualstudio.com/5e1d907d-b0b4-4272-be99-f3ac5c2e7a67/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.